### PR TITLE
propagating errors for FAILED jobs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -114,7 +114,7 @@ ___
 
 Ƭ **GetJobResultsOpts**: *object*
 
-*Defined in [src/query/query_service_models.ts:308](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L308)*
+*Defined in [src/query/query_service_models.ts:316](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L316)*
 
 Configuration options for the Get Job Results Query API call
 
@@ -138,7 +138,7 @@ ___
 
 Ƭ **GetJobsListOpts**: *object*
 
-*Defined in [src/query/query_service_models.ts:355](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L355)*
+*Defined in [src/query/query_service_models.ts:363](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L363)*
 
 Configuration options for the Get Jobs List Query API call
 
@@ -184,7 +184,7 @@ ___
 
 Ƭ **QueryApiError**: *object*
 
-*Defined in [src/query/query_service_models.ts:277](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L277)*
+*Defined in [src/query/query_service_models.ts:285](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L285)*
 
 Model of a query service error response
 
@@ -209,6 +209,8 @@ Detailed information about a query job
 #### Type declaration:
 
 * **endTime**? : *undefined | number*
+
+* **errors**? : *object[]*
 
 * **jobId**: *string*
 
@@ -264,7 +266,7 @@ ___
 
 Ƭ **QueryResultResp**: *object*
 
-*Defined in [src/query/query_service_models.ts:215](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L215)*
+*Defined in [src/query/query_service_models.ts:223](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L223)*
 
 Model of a query service result response
 
@@ -296,7 +298,7 @@ ___
 
 Ƭ **ResultFormat**: *"valuesArray" | "valuesDictionary"*
 
-*Defined in [src/query/query_service_models.ts:210](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L210)*
+*Defined in [src/query/query_service_models.ts:218](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L218)*
 
 The different formats a job query result could have
 
@@ -538,7 +540,7 @@ ___
 
 ▸ **isQueryApiError**(`obj`: any): *obj is QueryApiError*
 
-*Defined in [src/query/query_service_models.ts:298](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L298)*
+*Defined in [src/query/query_service_models.ts:306](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L306)*
 
 Convenience type guard function to check if an object conforms to the
 `QueryApiError` interface
@@ -559,7 +561,7 @@ ___
 
 ▸ **isQueryJobDetail**(`obj`: any): *obj is QueryJobDetail*
 
-*Defined in [src/query/query_service_models.ts:195](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L195)*
+*Defined in [src/query/query_service_models.ts:202](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L202)*
 
 Convenience type guard function to check if a object conforms to the
 `QueryJobDetail` interface
@@ -617,7 +619,7 @@ ___
 
 ▸ **isQueryResultResp**(`obj`: any): *obj is QueryResultResp*
 
-*Defined in [src/query/query_service_models.ts:264](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L264)*
+*Defined in [src/query/query_service_models.ts:272](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_models.ts#L272)*
 
 Convenienece method to check if an object conforms to the `QueryResultResp` interface
 

--- a/doc/classes/queryiterator.md
+++ b/doc/classes/queryiterator.md
@@ -32,7 +32,7 @@
 
 \+ **new QueryIterator**(`sqlCommand`: string, `qsc`: [QueryServiceClient](queryserviceclient.md), `cred?`: [CredentialTuple](../README.md#credentialtuple)): *[QueryIterator](queryiterator.md)*
 
-*Defined in [src/query/query_service_client.ts:90](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L90)*
+*Defined in [src/query/query_service_client.ts:91](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L91)*
 
 **Parameters:**
 
@@ -50,7 +50,7 @@ Name | Type |
 
 • **cred**? : *[CredentialTuple](../README.md#credentialtuple)*
 
-*Defined in [src/query/query_service_client.ts:90](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L90)*
+*Defined in [src/query/query_service_client.ts:91](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L91)*
 
 ## Methods
 
@@ -58,7 +58,7 @@ Name | Type |
 
 ▸ **[Symbol.asyncIterator]**(): *AsyncIterableIterator‹any›*
 
-*Defined in [src/query/query_service_client.ts:97](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L97)*
+*Defined in [src/query/query_service_client.ts:98](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L98)*
 
 **Returns:** *AsyncIterableIterator‹any›*
 
@@ -68,7 +68,7 @@ ___
 
 ▸ **next**(): *Promise‹IteratorResult‹any››*
 
-*Defined in [src/query/query_service_client.ts:101](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L101)*
+*Defined in [src/query/query_service_client.ts:102](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L102)*
 
 **Returns:** *Promise‹IteratorResult‹any››*
 
@@ -78,6 +78,6 @@ ___
 
 ▸ **return**(): *Promise‹IteratorResult‹any››*
 
-*Defined in [src/query/query_service_client.ts:121](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L121)*
+*Defined in [src/query/query_service_client.ts:122](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L122)*
 
 **Returns:** *Promise‹IteratorResult‹any››*

--- a/doc/classes/queryserviceclient.md
+++ b/doc/classes/queryserviceclient.md
@@ -44,7 +44,7 @@ Data Lake queries.
 
 *Overrides [QueryService](queryservice.md).[constructor](queryservice.md#constructor)*
 
-*Defined in [src/query/query_service_client.ts:216](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L216)*
+*Defined in [src/query/query_service_client.ts:217](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L217)*
 
 Use the constructor if you want to create a new `QueryService` object
 sharing an existing `HttpdFetch` object with other objects.
@@ -64,7 +64,7 @@ Name | Type | Description |
 
 • **autoClose**: *boolean*
 
-*Defined in [src/query/query_service_client.ts:216](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L216)*
+*Defined in [src/query/query_service_client.ts:217](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L217)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **delay**: *number*
 
-*Defined in [src/query/query_service_client.ts:214](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L214)*
+*Defined in [src/query/query_service_client.ts:215](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L215)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 • **pageSize**: *number*
 
-*Defined in [src/query/query_service_client.ts:213](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L213)*
+*Defined in [src/query/query_service_client.ts:214](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L214)*
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 • **retries**: *number*
 
-*Defined in [src/query/query_service_client.ts:215](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L215)*
+*Defined in [src/query/query_service_client.ts:216](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L216)*
 
 ## Methods
 
@@ -237,7 +237,7 @@ ___
 
 ▸ **iterator**(`sqlCommand`: string, `cred?`: [CredentialTuple](../README.md#credentialtuple)): *AsyncIterableIterator‹any[]›*
 
-*Defined in [src/query/query_service_client.ts:245](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L245)*
+*Defined in [src/query/query_service_client.ts:246](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L246)*
 
 Leverages ES2018 async iterator feature to return a way to iterate a
 Cortex Data Lake query response
@@ -259,7 +259,7 @@ ___
 
 ▸ **stream**(`sqlCommand`: string, `opts?`: ReadableOptions, `cred?`: [CredentialTuple](../README.md#credentialtuple)): *ReadableStream*
 
-*Defined in [src/query/query_service_client.ts:257](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L257)*
+*Defined in [src/query/query_service_client.ts:258](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L258)*
 
 Use this method to consume a Cortex Data Lake query reseult set using the
 NodeJS's Stream.Readable interface
@@ -284,7 +284,7 @@ ___
 
 *Overrides [QueryService](queryservice.md).[factory](queryservice.md#static-factory)*
 
-*Defined in [src/query/query_service_client.ts:233](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L233)*
+*Defined in [src/query/query_service_client.ts:234](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L234)*
 
 **Parameters:**
 

--- a/doc/classes/queryserviceclienterror.md
+++ b/doc/classes/queryserviceclienterror.md
@@ -20,11 +20,16 @@ get insights on why the operation could not be completed
 ### Properties
 
 * [errorType](queryserviceclienterror.md#errortype)
+* [errors](queryserviceclienterror.md#optional-errors)
 * [jobId](queryserviceclienterror.md#jobid)
 * [message](queryserviceclienterror.md#message)
 * [name](queryserviceclienterror.md#name)
 * [stack](queryserviceclienterror.md#optional-stack)
 * [status](queryserviceclienterror.md#status)
+
+### Methods
+
+* [fromQueryJobDetails](queryserviceclienterror.md#static-fromqueryjobdetails)
 
 ## Constructors
 
@@ -34,7 +39,7 @@ get insights on why the operation could not be completed
 
 *Overrides [SdkError](sdkerror.md).[constructor](sdkerror.md#constructor)*
 
-*Defined in [src/query/query_service_client_error.ts:29](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client_error.ts#L29)*
+*Defined in [src/query/query_service_client_error.ts:36](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client_error.ts#L36)*
 
 **Parameters:**
 
@@ -54,6 +59,16 @@ Name | Type |
 *Inherited from [SdkError](sdkerror.md).[errorType](sdkerror.md#errortype)*
 
 *Defined in [src/sdkError.ts:59](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/sdkError.ts#L59)*
+
+___
+
+### `Optional` errors
+
+• **errors**? : *object[]*
+
+*Defined in [src/query/query_service_client_error.ts:33](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client_error.ts#L33)*
+
+Provides additional information in case of error
 
 ___
 
@@ -104,3 +119,24 @@ ___
 *Defined in [src/query/query_service_client_error.ts:25](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client_error.ts#L25)*
 
 State of the job when the error was thrown
+
+## Methods
+
+### `Static` fromQueryJobDetails
+
+▸ **fromQueryJobDetails**(`jobDetail`: [QueryJobDetail](../README.md#queryjobdetail)): *[QueryServiceClientError](queryserviceclienterror.md)*
+
+*Defined in [src/query/query_service_client_error.ts:53](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client_error.ts#L53)*
+
+Takes a QueryJobDetail object (assuming to be in `FAIL` state) and builds
+a QueryServiceClientError from its data
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`jobDetail` | [QueryJobDetail](../README.md#queryjobdetail) | object to take data from |
+
+**Returns:** *[QueryServiceClientError](queryserviceclienterror.md)*
+
+a new QueryServiceClientError object

--- a/doc/classes/querystream.md
+++ b/doc/classes/querystream.md
@@ -67,7 +67,7 @@
 
 *Overrides void*
 
-*Defined in [src/query/query_service_client.ts:150](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L150)*
+*Defined in [src/query/query_service_client.ts:151](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L151)*
 
 **Parameters:**
 
@@ -150,7 +150,7 @@ ___
 
 *Overrides void*
 
-*Defined in [src/query/query_service_client.ts:171](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L171)*
+*Defined in [src/query/query_service_client.ts:172](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L172)*
 
 **Parameters:**
 
@@ -176,7 +176,7 @@ ___
 
 *Overrides void*
 
-*Defined in [src/query/query_service_client.ts:158](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L158)*
+*Defined in [src/query/query_service_client.ts:159](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L159)*
 
 **Returns:** *void*
 

--- a/doc/enums/readablestates.md
+++ b/doc/enums/readablestates.md
@@ -17,7 +17,7 @@
 
 • **CLOSED**:
 
-*Defined in [src/query/query_service_client.ts:132](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L132)*
+*Defined in [src/query/query_service_client.ts:133](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L133)*
 
 ___
 
@@ -25,7 +25,7 @@ ___
 
 • **CLOSING**:
 
-*Defined in [src/query/query_service_client.ts:131](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L131)*
+*Defined in [src/query/query_service_client.ts:132](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L132)*
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 • **LOADING**:
 
-*Defined in [src/query/query_service_client.ts:130](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L130)*
+*Defined in [src/query/query_service_client.ts:131](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L131)*
 
 ___
 
@@ -41,4 +41,4 @@ ___
 
 • **READY**:
 
-*Defined in [src/query/query_service_client.ts:129](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L129)*
+*Defined in [src/query/query_service_client.ts:130](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L130)*

--- a/doc/interfaces/queryserviceclientoptions.md
+++ b/doc/interfaces/queryserviceclientoptions.md
@@ -24,7 +24,7 @@ Configuration options for the QueryServiceClient object
 
 • **autoClose**? : *undefined | false | true*
 
-*Defined in [src/query/query_service_client.ts:201](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L201)*
+*Defined in [src/query/query_service_client.ts:202](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L202)*
 
 By default the iterator or stream will close the underlying HTTP2 session
 at the end. Switch this flag to false to revert this behaviour. You might
@@ -36,7 +36,7 @@ ___
 
 • **cred**? : *[CredentialTuple](../README.md#credentialtuple)*
 
-*Defined in [src/query/query_service_client.ts:205](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L205)*
+*Defined in [src/query/query_service_client.ts:206](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L206)*
 
 Default `Credentials` object to use by this object's methods
 
@@ -46,7 +46,7 @@ ___
 
 • **delay**? : *undefined | number*
 
-*Defined in [src/query/query_service_client.ts:191](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L191)*
+*Defined in [src/query/query_service_client.ts:192](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L192)*
 
 Milliseconds to wait before attempting the same call again (default: 200)
 
@@ -56,7 +56,7 @@ ___
 
 • **pageSize**? : *undefined | number*
 
-*Defined in [src/query/query_service_client.ts:187](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L187)*
+*Defined in [src/query/query_service_client.ts:188](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L188)*
 
 Max amount of response items in each page (default: 400)
 
@@ -66,6 +66,6 @@ ___
 
 • **retries**? : *undefined | number*
 
-*Defined in [src/query/query_service_client.ts:195](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L195)*
+*Defined in [src/query/query_service_client.ts:196](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L196)*
 
 Amount of retries of the same call (default: 10)

--- a/lib/query/query_service_client.js
+++ b/lib/query/query_service_client.js
@@ -49,7 +49,8 @@ class QueryWorker {
     async lazyInit() {
         if (this.jobId === null) {
             this.jobId = (await this.createJob({ jobId: uuid(), params: { query: this.sqlCommand } }, this.cred)).jobId;
-            let { state } = await this.getJobStatus(this.jobId, this.cred);
+            const jobDetail = await this.getJobStatus(this.jobId, this.cred);
+            let state = jobDetail.state;
             let attempts = 0;
             while ((state == 'PENDING' || state == 'RUNNING') && attempts++ < this.qsc.retries) {
                 state = await new Promise((res, rej) => setTimeout(async () => {
@@ -64,7 +65,7 @@ class QueryWorker {
             if (attempts >= this.qsc.retries)
                 throw new query_service_client_error_1.QueryServiceClientError(this.jobId, `JobId ${this.jobId} still in status ${state} after ${attempts} attempts`);
             if (state != 'DONE')
-                throw new query_service_client_error_1.QueryServiceClientError(this.jobId, `JobId ${this.jobId} failed with status ${state}`);
+                throw query_service_client_error_1.QueryServiceClientError.fromQueryJobDetails(jobDetail);
             await this.loadPage();
         }
     }

--- a/lib/query/query_service_client_error.d.ts
+++ b/lib/query/query_service_client_error.d.ts
@@ -1,5 +1,5 @@
 import { SdkError } from '../sdkError';
-import { JobState } from './query_service_models';
+import { JobState, QueryJobDetail } from './query_service_models';
 /**
  * Error subclass provided by `QueryServiceClient` objects that allow developer
  * get insights on why the operation could not be completed
@@ -13,5 +13,19 @@ export declare class QueryServiceClientError extends SdkError {
      * Job identifier associated to the operation
      */
     jobId: string;
+    /**
+     * Provides additional information in case of error
+     */
+    errors?: {
+        message: string;
+        context: string;
+    }[];
     constructor(jobId: string, ...params: any[]);
+    /**
+     * Takes a QueryJobDetail object (assuming to be in `FAIL` state) and builds
+     * a QueryServiceClientError from its data
+     * @param jobDetail object to take data from
+     * @returns a new QueryServiceClientError object
+     */
+    static fromQueryJobDetails(jobDetail: QueryJobDetail): QueryServiceClientError;
 }

--- a/lib/query/query_service_client_error.js
+++ b/lib/query/query_service_client_error.js
@@ -26,5 +26,16 @@ class QueryServiceClientError extends sdkError_1.SdkError {
             Error.captureStackTrace(this, QueryServiceClientError);
         }
     }
+    /**
+     * Takes a QueryJobDetail object (assuming to be in `FAIL` state) and builds
+     * a QueryServiceClientError from its data
+     * @param jobDetail object to take data from
+     * @returns a new QueryServiceClientError object
+     */
+    static fromQueryJobDetails(jobDetail) {
+        const clientError = new QueryServiceClientError(jobDetail.jobId, `JobId ${jobDetail.jobId} ended with status ${jobDetail.state}`);
+        clientError.errors = jobDetail.errors;
+        return clientError;
+    }
 }
 exports.QueryServiceClientError = QueryServiceClientError;

--- a/lib/query/query_service_models.d.ts
+++ b/lib/query/query_service_models.d.ts
@@ -143,6 +143,13 @@ export declare type QueryJobDetail = {
         cachePct?: number;
         etaMs?: number;
     };
+    /**
+     * Provides additional information in case of error
+     */
+    errors?: {
+        message: string;
+        context: string;
+    }[];
 };
 /**
  * Convenience type guard function to check if a object conforms to the

--- a/lib/query/query_service_models.js
+++ b/lib/query/query_service_models.js
@@ -61,7 +61,8 @@ function isQueryJobDetail(obj) {
         (obj.endTime === undefined || typeof obj.endTime == 'number') &&
         (obj.progress === undefined || typeof obj.progress == 'object' && typeof obj.progress.completionPct == 'number') &&
         (obj.params === undefined || typeof obj.params == 'object' && isQueryParams(obj.params)) &&
-        (obj.statistics === undefined || typeof obj.statistics == 'object');
+        (obj.statistics === undefined || typeof obj.statistics == 'object') &&
+        (obj.errors === undefined || typeof obj.errors == 'object');
 }
 exports.isQueryJobDetail = isQueryJobDetail;
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paloaltonetworks/pan-cortex-data-lake",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Palo Alto Networks Cortex Data Lake client library",
   "homepage": "https://github.com/PaloAltoNetworks/pan-cortex-data-lake-nodejs#readme",
   "repository": {

--- a/src/query/query_service_client_error.ts
+++ b/src/query/query_service_client_error.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { SdkError } from '../sdkError'
-import { JobState } from './query_service_models'
+import { JobState, QueryJobDetail } from './query_service_models'
 
 /**
  * Error subclass provided by `QueryServiceClient` objects that allow developer
@@ -27,6 +27,13 @@ export class QueryServiceClientError extends SdkError {
      * Job identifier associated to the operation
      */
     jobId: string
+    /**
+     * Provides additional information in case of error
+     */
+    errors?: {
+        message: string,
+        context: string
+    }[]
 
     constructor(jobId: string, ...params: any[]) {
         super('QueryClient', ...(params.length > 0 && params[0] instanceof Error) ? [params[0].message] : params)
@@ -35,5 +42,17 @@ export class QueryServiceClientError extends SdkError {
         if (Error.captureStackTrace) {
             Error.captureStackTrace(this, QueryServiceClientError)
         }
+    }
+
+    /**
+     * Takes a QueryJobDetail object (assuming to be in `FAIL` state) and builds
+     * a QueryServiceClientError from its data
+     * @param jobDetail object to take data from
+     * @returns a new QueryServiceClientError object
+     */
+    static fromQueryJobDetails(jobDetail: QueryJobDetail): QueryServiceClientError {
+        const clientError = new QueryServiceClientError(jobDetail.jobId, `JobId ${jobDetail.jobId} ended with status ${jobDetail.state}`)
+        clientError.errors = jobDetail.errors
+        return clientError
     }
 }

--- a/src/query/query_service_models.ts
+++ b/src/query/query_service_models.ts
@@ -184,6 +184,13 @@ export type QueryJobDetail = {
         cachePct?: number,
         etaMs?: number
     }
+    /**
+     * Provides additional information in case of error
+     */
+    errors?: {
+        message: string,
+        context: string
+    }[]
 }
 
 /**
@@ -201,7 +208,8 @@ export function isQueryJobDetail(obj: any): obj is QueryJobDetail {
         (obj.endTime === undefined || typeof obj.endTime == 'number') &&
         (obj.progress === undefined || typeof obj.progress == 'object' && typeof obj.progress.completionPct == 'number') &&
         (obj.params === undefined || typeof obj.params == 'object' && isQueryParams(obj.params)) &&
-        (obj.statistics === undefined || typeof obj.statistics == 'object')
+        (obj.statistics === undefined || typeof obj.statistics == 'object') &&
+        (obj.errors === undefined || typeof obj.errors == 'object')
 }
 
 /**


### PR DESCRIPTION
Error description in the QueryJobDetails response are now incorporated into a QueryServiceClient error for jobs with status FAILED

## Description

QueryServiceClient hides complexity (pagination, parsing, etc.). In case a SQL command generates an invalid JOB (state = FAILED) a QueryServiceClientError is thrown. Before this change a generic message was thrown.

## Motivation and Context

Developer using the QueryServiceClient abstraction (either iterator or Stream.Readable) might be interested in getting the error message provided by the Query API when marking a job as state = FAILED. Typical use case is to get the pointer in the SQL command string where the parser failed and the reason for it.

With this change these details are now incorporated into t QueryServiceClientError object

## How Has This Been Tested?

Forced an invalid SQL command using the abstract Iterator interface and checked the syntax error is now captured in the error thrown.

## Screenshots (if appropriate)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
