### PR TITLE
fix: report the current job status in runtime error

### DIFF
--- a/doc/classes/queryiterator.md
+++ b/doc/classes/queryiterator.md
@@ -32,7 +32,7 @@
 
 \+ **new QueryIterator**(`sqlCommand`: string, `qsc`: [QueryServiceClient](queryserviceclient.md), `cred?`: [CredentialTuple](../README.md#credentialtuple)): *[QueryIterator](queryiterator.md)*
 
-*Defined in [src/query/query_service_client.ts:91](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L91)*
+*Defined in [src/query/query_service_client.ts:92](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L92)*
 
 **Parameters:**
 
@@ -50,7 +50,7 @@ Name | Type |
 
 • **cred**? : *[CredentialTuple](../README.md#credentialtuple)*
 
-*Defined in [src/query/query_service_client.ts:91](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L91)*
+*Defined in [src/query/query_service_client.ts:92](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L92)*
 
 ## Methods
 
@@ -58,7 +58,7 @@ Name | Type |
 
 ▸ **[Symbol.asyncIterator]**(): *AsyncIterableIterator‹any›*
 
-*Defined in [src/query/query_service_client.ts:98](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L98)*
+*Defined in [src/query/query_service_client.ts:99](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L99)*
 
 **Returns:** *AsyncIterableIterator‹any›*
 
@@ -68,7 +68,7 @@ ___
 
 ▸ **next**(): *Promise‹IteratorResult‹any››*
 
-*Defined in [src/query/query_service_client.ts:102](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L102)*
+*Defined in [src/query/query_service_client.ts:103](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L103)*
 
 **Returns:** *Promise‹IteratorResult‹any››*
 
@@ -78,6 +78,6 @@ ___
 
 ▸ **return**(): *Promise‹IteratorResult‹any››*
 
-*Defined in [src/query/query_service_client.ts:122](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L122)*
+*Defined in [src/query/query_service_client.ts:123](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L123)*
 
 **Returns:** *Promise‹IteratorResult‹any››*

--- a/doc/classes/queryserviceclient.md
+++ b/doc/classes/queryserviceclient.md
@@ -44,7 +44,7 @@ Data Lake queries.
 
 *Overrides [QueryService](queryservice.md).[constructor](queryservice.md#constructor)*
 
-*Defined in [src/query/query_service_client.ts:217](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L217)*
+*Defined in [src/query/query_service_client.ts:218](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L218)*
 
 Use the constructor if you want to create a new `QueryService` object
 sharing an existing `HttpdFetch` object with other objects.
@@ -64,7 +64,7 @@ Name | Type | Description |
 
 • **autoClose**: *boolean*
 
-*Defined in [src/query/query_service_client.ts:217](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L217)*
+*Defined in [src/query/query_service_client.ts:218](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L218)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **delay**: *number*
 
-*Defined in [src/query/query_service_client.ts:215](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L215)*
+*Defined in [src/query/query_service_client.ts:216](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L216)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 • **pageSize**: *number*
 
-*Defined in [src/query/query_service_client.ts:214](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L214)*
+*Defined in [src/query/query_service_client.ts:215](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L215)*
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 • **retries**: *number*
 
-*Defined in [src/query/query_service_client.ts:216](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L216)*
+*Defined in [src/query/query_service_client.ts:217](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L217)*
 
 ## Methods
 
@@ -237,7 +237,7 @@ ___
 
 ▸ **iterator**(`sqlCommand`: string, `cred?`: [CredentialTuple](../README.md#credentialtuple)): *AsyncIterableIterator‹any[]›*
 
-*Defined in [src/query/query_service_client.ts:246](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L246)*
+*Defined in [src/query/query_service_client.ts:247](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L247)*
 
 Leverages ES2018 async iterator feature to return a way to iterate a
 Cortex Data Lake query response
@@ -259,7 +259,7 @@ ___
 
 ▸ **stream**(`sqlCommand`: string, `opts?`: ReadableOptions, `cred?`: [CredentialTuple](../README.md#credentialtuple)): *ReadableStream*
 
-*Defined in [src/query/query_service_client.ts:258](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L258)*
+*Defined in [src/query/query_service_client.ts:259](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L259)*
 
 Use this method to consume a Cortex Data Lake query reseult set using the
 NodeJS's Stream.Readable interface
@@ -284,7 +284,7 @@ ___
 
 *Overrides [QueryService](queryservice.md).[factory](queryservice.md#static-factory)*
 
-*Defined in [src/query/query_service_client.ts:234](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L234)*
+*Defined in [src/query/query_service_client.ts:235](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L235)*
 
 **Parameters:**
 

--- a/doc/classes/querystream.md
+++ b/doc/classes/querystream.md
@@ -67,7 +67,7 @@
 
 *Overrides void*
 
-*Defined in [src/query/query_service_client.ts:151](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L151)*
+*Defined in [src/query/query_service_client.ts:152](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L152)*
 
 **Parameters:**
 
@@ -150,7 +150,7 @@ ___
 
 *Overrides void*
 
-*Defined in [src/query/query_service_client.ts:172](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L172)*
+*Defined in [src/query/query_service_client.ts:173](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L173)*
 
 **Parameters:**
 
@@ -176,7 +176,7 @@ ___
 
 *Overrides void*
 
-*Defined in [src/query/query_service_client.ts:159](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L159)*
+*Defined in [src/query/query_service_client.ts:160](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L160)*
 
 **Returns:** *void*
 

--- a/doc/enums/readablestates.md
+++ b/doc/enums/readablestates.md
@@ -17,7 +17,7 @@
 
 • **CLOSED**:
 
-*Defined in [src/query/query_service_client.ts:133](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L133)*
+*Defined in [src/query/query_service_client.ts:134](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L134)*
 
 ___
 
@@ -25,7 +25,7 @@ ___
 
 • **CLOSING**:
 
-*Defined in [src/query/query_service_client.ts:132](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L132)*
+*Defined in [src/query/query_service_client.ts:133](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L133)*
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 • **LOADING**:
 
-*Defined in [src/query/query_service_client.ts:131](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L131)*
+*Defined in [src/query/query_service_client.ts:132](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L132)*
 
 ___
 
@@ -41,4 +41,4 @@ ___
 
 • **READY**:
 
-*Defined in [src/query/query_service_client.ts:130](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L130)*
+*Defined in [src/query/query_service_client.ts:131](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L131)*

--- a/doc/interfaces/queryserviceclientoptions.md
+++ b/doc/interfaces/queryserviceclientoptions.md
@@ -24,7 +24,7 @@ Configuration options for the QueryServiceClient object
 
 • **autoClose**? : *undefined | false | true*
 
-*Defined in [src/query/query_service_client.ts:202](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L202)*
+*Defined in [src/query/query_service_client.ts:203](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L203)*
 
 By default the iterator or stream will close the underlying HTTP2 session
 at the end. Switch this flag to false to revert this behaviour. You might
@@ -36,7 +36,7 @@ ___
 
 • **cred**? : *[CredentialTuple](../README.md#credentialtuple)*
 
-*Defined in [src/query/query_service_client.ts:206](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L206)*
+*Defined in [src/query/query_service_client.ts:207](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L207)*
 
 Default `Credentials` object to use by this object's methods
 
@@ -46,7 +46,7 @@ ___
 
 • **delay**? : *undefined | number*
 
-*Defined in [src/query/query_service_client.ts:192](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L192)*
+*Defined in [src/query/query_service_client.ts:193](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L193)*
 
 Milliseconds to wait before attempting the same call again (default: 200)
 
@@ -56,7 +56,7 @@ ___
 
 • **pageSize**? : *undefined | number*
 
-*Defined in [src/query/query_service_client.ts:188](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L188)*
+*Defined in [src/query/query_service_client.ts:189](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L189)*
 
 Max amount of response items in each page (default: 400)
 
@@ -66,6 +66,6 @@ ___
 
 • **retries**? : *undefined | number*
 
-*Defined in [src/query/query_service_client.ts:196](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L196)*
+*Defined in [src/query/query_service_client.ts:197](https://github.com/xhoms/pan-cortex-data-lake-nodejs/blob/master/src/query/query_service_client.ts#L197)*
 
 Amount of retries of the same call (default: 10)

--- a/lib/query/query_service_client.js
+++ b/lib/query/query_service_client.js
@@ -49,13 +49,14 @@ class QueryWorker {
     async lazyInit() {
         if (this.jobId === null) {
             this.jobId = (await this.createJob({ jobId: uuid(), params: { query: this.sqlCommand } }, this.cred)).jobId;
-            const jobDetail = await this.getJobStatus(this.jobId, this.cred);
+            let jobDetail = await this.getJobStatus(this.jobId, this.cred);
             let state = jobDetail.state;
             let attempts = 0;
             while ((state == 'PENDING' || state == 'RUNNING') && attempts++ < this.qsc.retries) {
                 state = await new Promise((res, rej) => setTimeout(async () => {
                     try {
-                        res((await this.getJobStatus(this.jobId, this.cred)).state);
+                        jobDetail = await this.getJobStatus(this.jobId, this.cred);
+                        res(jobDetail.state);
                     }
                     catch (e) {
                         rej(e);

--- a/src/query/query_service_client.ts
+++ b/src/query/query_service_client.ts
@@ -67,13 +67,14 @@ class QueryWorker {
             this.jobId = (await this.createJob(
                 { jobId: uuid(), params: { query: this.sqlCommand } },
                 this.cred)).jobId
-            const jobDetail = await this.getJobStatus(this.jobId, this.cred)
+            let jobDetail = await this.getJobStatus(this.jobId, this.cred)
             let state = jobDetail.state
             let attempts = 0
             while ((state == 'PENDING' || state == 'RUNNING') && attempts++ < this.qsc.retries) {
                 state = await new Promise((res, rej) => setTimeout(async () => {
                     try {
-                        res((await this.getJobStatus(this.jobId!, this.cred)).state)
+                        jobDetail = await this.getJobStatus(this.jobId!, this.cred)
+                        res(jobDetail.state)
                     } catch (e) {
                         rej(e)
                     }


### PR DESCRIPTION
Before this fix, an SQL job failing in the middle of the execution (i.e. due to division by zero) would report job status as RUNNING instead of FAILED

## Description

Inner loop update of the Job Status Detail to have latest information in case an error needs to be thrown

## Motivation and Context

A failure in the middle of a valid SQL execution would be propagated incorrectly by the library. With this fix the latest status is reported.

## How Has This Been Tested?

Forcing a division by zero query

## Screenshots (if appropriate)

N/A

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
